### PR TITLE
feat: adicionando autenticação como jwt

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -6,6 +6,7 @@ target/
 
 ### Secrets ###
 /src/main/resources/application-secrets.properties
+/src/main/resources/jwt-secrets.properties
 
 ### STS ###
 .apt_generated

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -22,6 +22,10 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.session</groupId>
+			<artifactId>spring-session-core</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
@@ -30,6 +34,19 @@
 			<groupId>se.michaelthelin.spotify</groupId>
 			<artifactId>spotify-web-api-java</artifactId>
 			<version>8.4.0</version>
+		</dependency>
+
+		<!-- Spring Security -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+
+		<!-- JWT -->
+		<dependency>
+			<groupId>com.auth0</groupId>
+			<artifactId>java-jwt</artifactId>
+			<version>4.4.0</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/src/main/java/dev/tccJoaoAmorim/backend/configs/SecurityConfig.java
+++ b/backend/src/main/java/dev/tccJoaoAmorim/backend/configs/SecurityConfig.java
@@ -1,0 +1,42 @@
+package dev.tccJoaoAmorim.backend.configs;
+
+import dev.tccJoaoAmorim.backend.infra.security.SecurityFilter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+public class SecurityConfig {
+
+    @Autowired
+    private SecurityFilter securityFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers((HttpMethod.GET), "/auth/spotify/login").permitAll()
+                        .requestMatchers((HttpMethod.GET), "/auth/spotify/callback").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin(form -> form.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+}

--- a/backend/src/main/java/dev/tccJoaoAmorim/backend/configs/WebConfig.java
+++ b/backend/src/main/java/dev/tccJoaoAmorim/backend/configs/WebConfig.java
@@ -1,0 +1,19 @@
+package dev.tccJoaoAmorim.backend.configs;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**") // Permite CORS para todos os endpoints
+                .allowedOrigins("http://localhost:4200", "https://accounts.spotify.com/authorize") // Origem permitida
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS") // Métodos HTTP permitidos
+                .allowedHeaders("*") // Permite qualquer cabeçalho
+                .allowCredentials(true) // Permite envio de cookies e credenciais
+                .maxAge(3600); // Tempo de cache da política (em segundos)
+    }
+}

--- a/backend/src/main/java/dev/tccJoaoAmorim/backend/controllers/ArtistController.java
+++ b/backend/src/main/java/dev/tccJoaoAmorim/backend/controllers/ArtistController.java
@@ -2,6 +2,7 @@ package dev.tccJoaoAmorim.backend.controllers;
 
 import dev.tccJoaoAmorim.backend.models.TopArtists;
 import dev.tccJoaoAmorim.backend.services.ArtistService;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,8 +19,8 @@ public class ArtistController {
     }
 
     @GetMapping("/top")
-    public TopArtists getUserTopArtists() {
-        return artistService.getUserTopArtists();
+    public TopArtists getUserTopArtists(HttpServletRequest request) {
+        return artistService.getUserTopArtists(request);
     }
 
 

--- a/backend/src/main/java/dev/tccJoaoAmorim/backend/controllers/GraphicController.java
+++ b/backend/src/main/java/dev/tccJoaoAmorim/backend/controllers/GraphicController.java
@@ -4,6 +4,8 @@ import dev.tccJoaoAmorim.backend.models.Artist;
 import dev.tccJoaoAmorim.backend.models.Track;
 import dev.tccJoaoAmorim.backend.models.TrackFeatures;
 import dev.tccJoaoAmorim.backend.services.GraphicService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,6 +19,7 @@ public class GraphicController {
 
     private final GraphicService graphicService;
 
+    @Autowired
     public GraphicController(GraphicService graphicService) {
         this.graphicService = graphicService;
     }
@@ -32,17 +35,17 @@ public class GraphicController {
     }
 
     @GetMapping("/track/popularity/top")
-    public List<Track> getTopTracksWithPopularity() {
-        return graphicService.getTopTracksWithPopularity();
+    public List<Track> getTopTracksWithPopularity(HttpServletRequest request) {
+        return graphicService.getTopTracksWithPopularity(request);
     }
 
     @GetMapping("/track/features/top")
-    public ArrayList<TrackFeatures> getTopTracksWithFeatures() {
-        return graphicService.getTopTracksWithFeatures();
+    public ArrayList<TrackFeatures> getTopTracksWithFeatures(HttpServletRequest request) {
+        return graphicService.getTopTracksWithFeatures(request);
     }
 
     @GetMapping("/artist/popularity/top")
-    public List<Artist> topPopularityArtists() {
-        return graphicService.getTopArtistsByPopularity();
+    public List<Artist> topPopularityArtists(HttpServletRequest request) {
+        return graphicService.getTopArtistsByPopularity(request);
     }
 }

--- a/backend/src/main/java/dev/tccJoaoAmorim/backend/controllers/SpotifyAuthController.java
+++ b/backend/src/main/java/dev/tccJoaoAmorim/backend/controllers/SpotifyAuthController.java
@@ -1,12 +1,9 @@
 package dev.tccJoaoAmorim.backend.controllers;
 
 import dev.tccJoaoAmorim.backend.services.SpotifyAuthService;
-import dev.tccJoaoAmorim.backend.services.TokenService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import dev.tccJoaoAmorim.backend.services.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.view.RedirectView;
 
 @RestController
@@ -14,10 +11,11 @@ import org.springframework.web.servlet.view.RedirectView;
 public class SpotifyAuthController {
 
     private final SpotifyAuthService spotifyAuthService;
+    private final UserService userService;
 
-    @Autowired
-    public SpotifyAuthController(SpotifyAuthService spotifyAuthService, TokenService tokenService) {
+    public SpotifyAuthController(SpotifyAuthService spotifyAuthService, UserService userService) {
         this.spotifyAuthService = spotifyAuthService;
+        this.userService = userService;
     }
 
     @GetMapping("/spotify/login")
@@ -28,12 +26,15 @@ public class SpotifyAuthController {
     }
 
     // Após a autorização, o Spotify redirecionará de volta para este URI com o código de autorização
+    // att: estou mudando para enviar o jwtToken gerado ao invés do accessToken do spotify
     @GetMapping("/spotify/callback")
-    public RedirectView getAccessToken(@RequestParam("code") String code) {
-        this.spotifyAuthService.getAccessToken(code);
+    public RedirectView getAccessToken(@RequestParam("code") String code, HttpServletRequest request) {
+        String accessToken = this.spotifyAuthService.getAccessToken(code);
+        String userId = this.userService.getUserInfo(accessToken).getId();
+        String jwtToken = this.spotifyAuthService.getJwtToken(accessToken, userId);
         RedirectView redirectView = new RedirectView();
-        redirectView.setUrl("http://localhost:4200");
-
+        redirectView.setUrl("http://localhost:4200/spotify/callback?token=" + jwtToken);
+        //return ResponseEntity.ok(jwtToken);
         return redirectView;
     }
 

--- a/backend/src/main/java/dev/tccJoaoAmorim/backend/controllers/TrackController.java
+++ b/backend/src/main/java/dev/tccJoaoAmorim/backend/controllers/TrackController.java
@@ -3,6 +3,7 @@ package dev.tccJoaoAmorim.backend.controllers;
 import dev.tccJoaoAmorim.backend.models.TopTracks;
 import dev.tccJoaoAmorim.backend.models.TrackFeatures;
 import dev.tccJoaoAmorim.backend.services.TrackService;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,12 +21,12 @@ public class TrackController {
     }
 
     @GetMapping("/features/{id}")
-    public TrackFeatures getTrackFeatures(@PathVariable String id) {
-        return trackService.getTrackFeatures(id);
+    public TrackFeatures getTrackFeatures(@PathVariable String id, HttpServletRequest request) {
+        return trackService.getTrackFeatures(id, request);
     }
 
     @GetMapping("/top")
-    public TopTracks getUserTopTracks() {
-        return trackService.getUserTopTracks();
+    public TopTracks getUserTopTracks(HttpServletRequest request) {
+        return trackService.getUserTopTracks(request);
     }
 }

--- a/backend/src/main/java/dev/tccJoaoAmorim/backend/controllers/UserController.java
+++ b/backend/src/main/java/dev/tccJoaoAmorim/backend/controllers/UserController.java
@@ -1,6 +1,5 @@
 package dev.tccJoaoAmorim.backend.controllers;
 
-import dev.tccJoaoAmorim.backend.models.User;
 import dev.tccJoaoAmorim.backend.services.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
@@ -16,8 +15,8 @@ public class UserController {
         this.userService = userService;
     }
 
-    @GetMapping("/info")
-    public User getUserInfo() {
-        return userService.getUserInfo();
-    }
+//    @GetMapping("/info")
+//    public User getUserInfo(HttpServletRequest request) {
+//        return userService.getUserInfo(request);
+//    }
 }

--- a/backend/src/main/java/dev/tccJoaoAmorim/backend/infra/security/JwtTokenService.java
+++ b/backend/src/main/java/dev/tccJoaoAmorim/backend/infra/security/JwtTokenService.java
@@ -1,0 +1,63 @@
+package dev.tccJoaoAmorim.backend.infra.security;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTCreationException;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+@Service
+public class JwtTokenService {
+
+    @Value("${jwt.token.secret}")
+    private String secret;
+
+    public String generateToken(String accessToken, String userId) {
+
+        try {
+            Algorithm algorithm = Algorithm.HMAC256(secret);
+            String token = JWT.create()
+                    .withIssuer("backend-tcc")
+                    .withSubject(userId)
+                    .withClaim("accessToken", accessToken)
+                    .withExpiresAt(generateExpirationDate())
+                    .withIssuedAt(Instant.now())
+                    .sign(algorithm);
+            return token;
+        } catch(JWTCreationException exception) {
+            throw new RuntimeException("Error while generating token: " + exception);
+        }
+    }
+
+    public DecodedJWT validateToken(String token) {
+        try {
+            Algorithm algorithm = Algorithm.HMAC256(secret);
+            return JWT.require(algorithm)
+                    .withIssuer("backend-tcc")
+                    .build()
+                    .verify(token);
+        } catch (JWTVerificationException exception) {
+            throw new RuntimeException("Error while validating token: " + exception);
+        }
+    }
+
+    private Instant generateExpirationDate() {
+        return LocalDateTime.now().plusHours(1).toInstant(ZoneOffset.of("-03:00"));
+    }
+
+    public String getJwtAccessToken(String jwtToken) {
+        String jwt = jwtToken.replace("Bearer ", "");
+
+        // Primeiro valida o token
+        DecodedJWT decodedJWT = validateToken(jwt);
+
+        // Retorna o accessToken do claim
+        return decodedJWT.getClaim("accessToken").asString();
+    }
+}

--- a/backend/src/main/java/dev/tccJoaoAmorim/backend/infra/security/SecurityFilter.java
+++ b/backend/src/main/java/dev/tccJoaoAmorim/backend/infra/security/SecurityFilter.java
@@ -1,0 +1,49 @@
+package dev.tccJoaoAmorim.backend.infra.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Component
+public class SecurityFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private JwtTokenService jwtTokenService;
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        var token = this.recoverToken(request);
+        if(token != null) {
+            var decodedJWT = this.jwtTokenService.validateToken(token);
+            String userId = decodedJWT.getSubject();
+            String accessToken = decodedJWT.getClaim("accessToken").asString();
+
+            var authentication = new UsernamePasswordAuthenticationToken(
+                    userId, // Identificador do usuário (principal)
+                    null,          // Sem credenciais
+                    Collections.emptyList() // Authorities podem ser vazias
+            );
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            // Adiciona ao request
+            request.setAttribute("spotifyAccessToken", accessToken);
+            request.setAttribute("userId", userId);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String recoverToken(HttpServletRequest request) {
+        var authHeader = request.getHeader("Authorization");
+        if(authHeader == null) return null;
+        return authHeader.replace("Bearer ", "");
+    }
+}

--- a/backend/src/main/java/dev/tccJoaoAmorim/backend/services/ArtistService.java
+++ b/backend/src/main/java/dev/tccJoaoAmorim/backend/services/ArtistService.java
@@ -1,6 +1,9 @@
 package dev.tccJoaoAmorim.backend.services;
 
+import dev.tccJoaoAmorim.backend.infra.security.JwtTokenService;
 import dev.tccJoaoAmorim.backend.models.TopArtists;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -8,15 +11,21 @@ import org.springframework.web.client.RestTemplate;
 @Service
 public class ArtistService {
 
+    @Autowired
     private final TokenService tokenService;
+    private final JwtTokenService jwtTokenService;
 
-    public ArtistService(TokenService tokenService) {
+    public ArtistService(TokenService tokenService, JwtTokenService jwtTokenService) {
         this.tokenService = tokenService;
+        this.jwtTokenService = jwtTokenService;
     }
 
-    public TopArtists getUserTopArtists() {
+    public TopArtists getUserTopArtists(HttpServletRequest request) {
         HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", tokenService.getAccessToken());
+
+        String accessToken = jwtTokenService.getJwtAccessToken(request.getHeader("Authorization"));
+
+        headers.set("Authorization", accessToken);
         headers.setContentType(MediaType.APPLICATION_JSON);
 
         HttpEntity<String> entity = new HttpEntity<>(headers);

--- a/backend/src/main/java/dev/tccJoaoAmorim/backend/services/GraphicService.java
+++ b/backend/src/main/java/dev/tccJoaoAmorim/backend/services/GraphicService.java
@@ -3,6 +3,7 @@ package dev.tccJoaoAmorim.backend.services;
 import dev.tccJoaoAmorim.backend.models.Artist;
 import dev.tccJoaoAmorim.backend.models.Track;
 import dev.tccJoaoAmorim.backend.models.TrackFeatures;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -25,23 +26,23 @@ public class GraphicService {
     // seria encontrar uma forma de retornar os dados diretos para colocar
     // no gráfico de forma mais simples. Nesse caso, só a List pode acabar
     // servindo, pois só usaremos as informações dessa List.
-    public List<Track> getTopTracksWithPopularity() {
-        return trackService.getUserTopTracks().getItems();
+    public List<Track> getTopTracksWithPopularity(HttpServletRequest request) {
+        return trackService.getUserTopTracks(request).getItems();
     }
 
-    public ArrayList<TrackFeatures> getTopTracksWithFeatures() {
-        List<Track> tracks = trackService.getUserTopTracks().getItems();
+    public ArrayList<TrackFeatures> getTopTracksWithFeatures(HttpServletRequest request) {
+        List<Track> tracks = trackService.getUserTopTracks(request).getItems();
         ArrayList<TrackFeatures> tracksFeatures = new ArrayList<>();
 
         tracks.forEach(track -> {
-            tracksFeatures.add(trackService.getTrackFeatures(track.getId()));
+            tracksFeatures.add(trackService.getTrackFeatures(track.getId(), request));
         });
 
         return tracksFeatures;
     }
 
-    public List<Artist> getTopArtistsByPopularity() {
-        return artistService.getUserTopArtists().getItems();
+    public List<Artist> getTopArtistsByPopularity(HttpServletRequest request) {
+        return artistService.getUserTopArtists(request).getItems();
     }
 
 

--- a/backend/src/main/java/dev/tccJoaoAmorim/backend/services/TokenService.java
+++ b/backend/src/main/java/dev/tccJoaoAmorim/backend/services/TokenService.java
@@ -1,14 +1,20 @@
 package dev.tccJoaoAmorim.backend.services;
 
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Service;
 
 @Service
+@Scope(value = "session", proxyMode = ScopedProxyMode.TARGET_CLASS)
 public class TokenService {
 
     private String accessToken;
 
+    public TokenService() {
+    }
+
     public String getAccessToken() {
-        return accessToken;
+        return this.accessToken;
     }
 
     public void setAccessToken(String accessToken) {

--- a/backend/src/main/java/dev/tccJoaoAmorim/backend/services/TrackService.java
+++ b/backend/src/main/java/dev/tccJoaoAmorim/backend/services/TrackService.java
@@ -1,7 +1,9 @@
 package dev.tccJoaoAmorim.backend.services;
 
+import dev.tccJoaoAmorim.backend.infra.security.JwtTokenService;
 import dev.tccJoaoAmorim.backend.models.TopTracks;
 import dev.tccJoaoAmorim.backend.models.TrackFeatures;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -10,14 +12,19 @@ import org.springframework.web.client.RestTemplate;
 public class TrackService {
 
     private final TokenService tokenService;
+    private final JwtTokenService jwtTokenService;
 
-    public TrackService(TokenService tokenService) {
+    public TrackService(TokenService tokenService, JwtTokenService jwtTokenService) {
         this.tokenService = tokenService;
+        this.jwtTokenService = jwtTokenService;
     }
 
-    public TopTracks getUserTopTracks() {
+    public TopTracks getUserTopTracks(HttpServletRequest request) {
         HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", tokenService.getAccessToken());
+
+        String accessToken = jwtTokenService.getJwtAccessToken(request.getHeader("Authorization"));
+
+        headers.set("Authorization", accessToken);
         headers.setContentType(MediaType.APPLICATION_JSON);
 
         HttpEntity<String> entity = new HttpEntity<>(headers);
@@ -32,9 +39,11 @@ public class TrackService {
         return response.getBody();
     }
 
-    public TrackFeatures getTrackFeatures(String id) {
+    public TrackFeatures getTrackFeatures(String id, HttpServletRequest request) {
         HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", tokenService.getAccessToken());
+        String accessToken = jwtTokenService.getJwtAccessToken(request.getHeader("Authorization"));
+
+        headers.set("Authorization", accessToken);
         headers.setContentType(MediaType.APPLICATION_JSON);
 
         HttpEntity<String> entity = new HttpEntity<>(headers);

--- a/backend/src/main/java/dev/tccJoaoAmorim/backend/services/UserService.java
+++ b/backend/src/main/java/dev/tccJoaoAmorim/backend/services/UserService.java
@@ -1,6 +1,7 @@
 package dev.tccJoaoAmorim.backend.services;
 
 import dev.tccJoaoAmorim.backend.models.User;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -14,9 +15,10 @@ public class UserService {
         this.tokenService = tokenService;
     }
 
-    public User getUserInfo() {
+    public User getUserInfo(String accessToken) {
         HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", this.tokenService.getAccessToken());
+
+        headers.set("Authorization", accessToken);
         headers.setContentType(MediaType.APPLICATION_JSON);
 
         HttpEntity<String> entity = new HttpEntity<>(headers);

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=backend
 
 spring.profiles.active=dev
-spring.config.import=classpath:application-secrets.properties
+spring.config.import=classpath:application-secrets.properties,classpath:jwt-secrets.properties
 # ===============================
 # DATA SOURCE
 # ===============================
@@ -15,3 +15,6 @@ spring.config.import=classpath:application-secrets.properties
 #spring.jpa.show-sql=true
 #spring.jpa.hibernate.ddl-auto=update
 #spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+# ===============================
+logging.level.org.springframework.web=DEBUG
+logging.level.org.springframework.session=DEBUG


### PR DESCRIPTION
Vários usuário conseguem fazer requisições para o backend sem conflitos utilizando o JWT que é passado no header das requisições para diferenciá-los. dentro do claim do JWT está armazenado o accessToken para o backend fazer as requisições ao Spotify.